### PR TITLE
fix usage of composed stage in pipeline; add tests

### DIFF
--- a/pipeline/pipeline/pipeline.py
+++ b/pipeline/pipeline/pipeline.py
@@ -86,8 +86,8 @@ class PipelineStage(Generic[TStageInput, TStageResult], metaclass=TypeAnnotatedM
                 f"Output type of {self} ({self.TStageResult}) does not match input type of {other} ({other.TStageInput})."
             )
 
-        class CombinedStage(PipelineStage[TStageInput, TStageOther]):
-            def transform(_self, input: TStageInput) -> Iterable[TStageOther]:
+        class CombinedStage(PipelineStage[self.TStageInput, other.TStageResult]):
+            def transform(_self, input: self.TStageInput) -> Iterable[TStageOther]:
                 """Sequentially transform data from both stages."""
                 intermediate_results = self.run(input)
                 final_results = []

--- a/pipeline/tests/test_pipeline.py
+++ b/pipeline/tests/test_pipeline.py
@@ -390,3 +390,24 @@ def test_transform_then_produce():
     result = list(combined_stage(4))
 
     assert result == ["injected", "Processed: 8"]
+
+
+# Most common case: First stage has transform, second stage has transform
+def test_transform_then_transform():
+    stage1 = CustomStage[int, int](transform=lambda x: [x * 2])
+    stage2 = CustomStage[int, str](transform=lambda x: [f"Value: {x}"])
+
+    combined_stage = stage1 >> stage2
+    result = list(combined_stage(3))
+
+    assert result == ["Value: 6"]
+
+
+def test_composed_stage_in_pipeline():
+    stage1 = CustomStage[int, int](transform=lambda x: [x * 2])
+    stage2 = CustomStage[int, str](transform=lambda x: [f"Value: {x}"])
+
+    pipeline = Pipeline[int, str]([stage1 >> stage2])
+    result = pipeline(3)
+
+    assert result == ["Value: 6"]


### PR DESCRIPTION
The annotations of a composed stage did not meet requirements to safely use in a pipeline.

Fixed that and added tests to verify