### PR TITLE
fix WriteJsonToFile library

### DIFF
--- a/pipeline/pipeline/library.py
+++ b/pipeline/pipeline/library.py
@@ -1,10 +1,11 @@
 
 
 from collections.abc import Callable
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 import json
 import pathlib
 import os
+import msgspec
 
 from .pipeline import TStageInput, TStageResult, PipelineStage
 
@@ -75,9 +76,9 @@ class WriteJsonToFile(PipelineStage[TStageInput, TStageResult]):
             pass
 
     def to_json(self, input: TStageInput) -> str:
-        return json.dumps(asdict(input), indent=4)
+        return json.dumps(msgspec.structs.asdict(input), default=str, sort_keys=True, indent=4).encode('utf-8')
 
     def consume(self, input: TStageInput) -> None:
-        full_file_name = os.path.join(self.target_directory, self.get_filename(input))
-        with open(full_file_name, "w", encoding='utf-8') as file:
+        full_file_name = os.path.join(self.target_directory, f"{self.get_filename(input)}.json")
+        with open(full_file_name, "wb") as file:
             file.write(self.to_json(input))

--- a/pipeline/tests/test_library.py
+++ b/pipeline/tests/test_library.py
@@ -1,6 +1,7 @@
 
 from dataclasses import dataclass
 import json
+from msgspec import Struct
 
 import sys
 import pathlib
@@ -11,8 +12,7 @@ from pipeline.library import WriteJsonToFile, FormatPrintToConsole
 
 
 @to_filename(lambda _: "mock_file")
-@dataclass
-class MockInput:
+class MockInput(Struct):
     data: str
 
     def __str__(self):
@@ -83,26 +83,26 @@ def test_format_print_to_console_all_formatters():
 def test_write_json_to_file_to_json():
     input_data = MockInput(data="test data")
     stage = WriteJsonToFile(target_directory=".")
-    expected_json = json.dumps({"data": "test data"}, indent=4)
+    expected_json = json.dumps({"data": "test data"}, indent=4).encode("utf-8")
     assert stage.to_json(input_data) == expected_json
 
 
 def test_write_json_to_file_to_json_empty_data():
     input_data = MockInput(data="")
     stage = WriteJsonToFile(target_directory=".")
-    expected_json = json.dumps({"data": ""}, indent=4)
+    expected_json = json.dumps({"data": ""}, indent=4).encode("utf-8")
     assert stage.to_json(input_data) == expected_json
 
 
 def test_write_json_to_file_to_json_special_characters():
     input_data = MockInput(data="test data with special characters: !@#$%^&*()")
     stage = WriteJsonToFile(target_directory=".")
-    expected_json = json.dumps({"data": "test data with special characters: !@#$%^&*()"}, indent=4)
+    expected_json = json.dumps({"data": "test data with special characters: !@#$%^&*()"}, indent=4).encode("utf-8")
     assert stage.to_json(input_data) == expected_json
 
 
 def test_write_json_to_file_to_json_unicode_characters():
     input_data = MockInput(data="test data with unicode: üñîçødë")
     stage = WriteJsonToFile(target_directory=".")
-    expected_json = json.dumps({"data": "test data with unicode: üñîçødë"}, indent=4)
+    expected_json = json.dumps({"data": "test data with unicode: üñîçødë"}, indent=4).encode("utf-8")
     assert stage.to_json(input_data) == expected_json


### PR DESCRIPTION
Objects in the file-system-coupled pipeline are serialized and deserialized using msgspec, so the `WriteJsonToFile` pipeline stage should accept that - this means that `asdict` from `dataclasses` won't work on these objects and one must use `msgspec.structs.asdict` instead